### PR TITLE
fixed the error with Qminimize -u when there're windows without the "minimized" property

### DIFF
--- a/Qminimize
+++ b/Qminimize
@@ -65,7 +65,7 @@ def minimized_windows_list(minimized_icons):
     windows = (c.items("window")[1][1:])
     for i in windows:
         cont = windows.index(i)
-        if c.window[i].info()["minimized"] is True:
+        if "minimized" in c.window[i].info() and c.window[i].info()["minimized"] is True:
             string += "{} {}\\0icon\\x1f{}".format(c.window[i].info()["name"], str(c.window[i].info()["id"]), minimized_icons[cont])
             if cont < len(windows) - 1:
                 string += "\n"


### PR DESCRIPTION
this error was occurring to me because Qtile actually considers the top bar a window for some reason, and the "minimized" property is not present there. i added a small tweak so that `minimized_windows_list` checks if a window has that property to begin with and then checks if it's true.